### PR TITLE
fix: Failing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 
 before_script:
   - npm install -g grunt-cli
-  - mkdir ~/bin
+  - mkdir ~/bin || true
   - export PATH=~/bin:$PATH
   - npm install --dev
 


### PR DESCRIPTION
Do not let `mkdir` fail when directory already exists